### PR TITLE
Fix field name

### DIFF
--- a/content/api-references/trading-api/account.md
+++ b/content/api-references/trading-api/account.md
@@ -8,7 +8,7 @@ weight: 10
 The account API serves important information related to an account,
 including account status, funds available for trade, funds available for
 withdrawal, and various flags relevant to an account's ability to trade.
-An account maybe be blocked for just for trades (`trades_blocked` flag) or for both
+An account maybe be blocked for just for trades (`trading_blocked` flag) or for both
 trades and transfers (`account_blocked` flag) if Alpaca identifies the account to
 engaging in any suspicious activity. Also, in accordance with FINRA's pattern day
 trading rule, an account may be flagged for pattern day trading


### PR DESCRIPTION
- [x] Fix field name from `trades_blocked` to `trading_blocked`

As shown in below screenshots, the field name is `trading_blocked`, I also tried the APIs and made sure `trading_blocked` was returned.

<img width="500" alt="Screen Shot 2022-02-27 at 11 48 14 AM" src="https://user-images.githubusercontent.com/65585157/155894774-eca4aa3a-71b3-4364-b4ae-244c97cec437.png">


<img width="528" alt="Screen Shot 2022-02-27 at 11 48 05 AM" src="https://user-images.githubusercontent.com/65585157/155894773-ba3dfa5b-0568-4bc6-aeb9-9f5f9a3473c4.png">
