### PR TITLE
Remove trailing spaces

### DIFF
--- a/assets/_custom.scss
+++ b/assets/_custom.scss
@@ -214,7 +214,7 @@ aside.desktop-top-aside {
         padding: 10px 22px;
         margin: 10px 0 0 0;
         box-sizing: border-box;
-        
+
         outline: none;
         -webkit-tap-highlight-color: transparent;
         -webkit-touch-callout: none;
@@ -223,7 +223,7 @@ aside.desktop-top-aside {
         -moz-user-select: none;
         -ms-user-select: none;
         user-select: none;
-      
+
         &:focus {
           outline: none !important;
         }
@@ -231,7 +231,7 @@ aside.desktop-top-aside {
         &:hover {
           opacity: .5;
         }
-    
+
         &.active {
           border-bottom: 5px var(--body-font-color) solid;
           margin-bottom: -5px;

--- a/assets/openapi.yaml
+++ b/assets/openapi.yaml
@@ -664,7 +664,7 @@ components:
         Disclosures fields denote if the account owner falls under
         each category defined by FINRA rule. The client has to ask
         questions for the end user and the values should reflect
-        their answers. 
+        their answers.
         If one of the answers is true (yes), the account goes into
         ACTION_REQUIRED status.
       properties:
@@ -2029,7 +2029,7 @@ paths:
       tags:
         - Documents
       description: |
-        You can query account documents such as monthly 
+        You can query account documents such as monthly
         statements and trade confirms under an account.
       parameters:
         - name: account_id

--- a/content/api-references/broker-api/accounts/accounts.md
+++ b/content/api-references/broker-api/accounts/accounts.md
@@ -273,7 +273,7 @@ In addition, only one of the following is **required**,
 | `family`            | Family            |
 
 #### Visa Type
-In addition to the following USA visa categories, we accept any sub visas of the list below. Sub visas must be passed in according to their parent category. Note that United States green card holders are considered permanent residents and should not pass in a visa type. 
+In addition to the following USA visa categories, we accept any sub visas of the list below. Sub visas must be passed in according to their parent category. Note that United States green card holders are considered permanent residents and should not pass in a visa type.
 
 | Attribute | Description                 |
 | --------- | --------------------------- |
@@ -354,7 +354,7 @@ Accounts API supports fixtures in Sandbox Environment. You can pass the desired 
 
 #### Sample Fixture
 
-Simulating a rejected account. 
+Simulating a rejected account.
 
 ```json
 {
@@ -698,7 +698,7 @@ If all parameters are valid and updates have been made, it returns with status c
 _Some server error occurred. Please contact Alpaca._
 {{</hint>}}
 
---- 
+---
 
 ## **Uploading CIP information**
 
@@ -946,7 +946,7 @@ Note: The dates collected on the form are in a slightly different format than ho
 
 #### Sample Request Body
 
-Note: This W-8 BEN sample is document object that will be included in the documents parameter of the account object. 
+Note: This W-8 BEN sample is document object that will be included in the documents parameter of the account object.
 
 ```json
 {

--- a/content/api-references/broker-api/corporate-actions/announcements.md
+++ b/content/api-references/broker-api/corporate-actions/announcements.md
@@ -7,9 +7,9 @@ summary: Open brokerage accounts, enable commission-free trading, and manage the
 
 # Announcements
 
-The announcements endpoint contains public information on previous and upcoming dividends, mergers, spinoffs, and stock splits. 
+The announcements endpoint contains public information on previous and upcoming dividends, mergers, spinoffs, and stock splits.
 
-Announcement data is made available through the API as soon as it is ingested by Alpaca, which is typically the following trading day after the declaration date. This provides insight into future account stock position and cash balance changes that will take effect on an announcement’s payable date. Additionally, viewing previous announcement details can improve bookkeeping and reconciling previous account cash and position changes. 
+Announcement data is made available through the API as soon as it is ingested by Alpaca, which is typically the following trading day after the declaration date. This provides insight into future account stock position and cash balance changes that will take effect on an announcement’s payable date. Additionally, viewing previous announcement details can improve bookkeeping and reconciling previous account cash and position changes.
 
 ---
 
@@ -81,7 +81,7 @@ This enables searching for an array of corporate action announcements based on c
 
 ### Response
 
-An array of Announcement objects. 
+An array of Announcement objects.
 
 #### Sample Response
 

--- a/content/api-references/broker-api/funding/ACH.md
+++ b/content/api-references/broker-api/funding/ACH.md
@@ -146,16 +146,16 @@ _`account_id` or `relationship_id` invalid_
 {{</hint>}}
 
 ---
- 
+
 ## **Plaid Integration for Bank Transfers**
 
-We have integrated with Plaid to allow you to seamlessly link your Plaid account to Alpaca. The integration will allow your end-users to verify their account instantly through Plaid’s trusted front-end module. 
+We have integrated with Plaid to allow you to seamlessly link your Plaid account to Alpaca. The integration will allow your end-users to verify their account instantly through Plaid’s trusted front-end module.
 
-Leveraging this allows you to generate Plaid Processor Tokens on behalf of your end-users, which allows Alpaca to immediately retrieve a user's bank details in order to deposit or withdraw funds on the Alpaca platform. 
+Leveraging this allows you to generate Plaid Processor Tokens on behalf of your end-users, which allows Alpaca to immediately retrieve a user's bank details in order to deposit or withdraw funds on the Alpaca platform.
 
 You can utilize your Plaid account and activate the Alpaca integration within the Plaid dashboard.
 
-The integration requires [Plaid API Keys](https://plaid.com/docs/auth/partnerships/alpaca/) 
+The integration requires [Plaid API Keys](https://plaid.com/docs/auth/partnerships/alpaca/)
 
 ### Obtaining a Plaid Processor Token
 A Plaid processor token is used to enable Plaid integrations with partners. After a customer connects their bank using Plaid Link, a processor token can be generated at any time. Please refer to the [Plaid Processor Token](https://plaid.com/docs/auth/partnerships/alpaca/) using Alpaca page for creating a token and additional details.
@@ -172,7 +172,7 @@ curl -X POST https://sandbox.plaid.com/item/public_token/exchange \
   }'
   ```
  Create a processor token for a specific account id.
-  
+
   ```bash
 curl -X POST https://sandbox.plaid.com/processor/token/create \
   -H 'Content-Type: application/json' \
@@ -187,7 +187,7 @@ curl -X POST https://sandbox.plaid.com/processor/token/create \
 
 For a valid request, the API will return a JSON response similar to:
 ```json
-{ 
+{
   "processor_token": "processor-sandbox-0asd1-a92nc",
   "request_id": "m8MDnv9okwxFNBV"
 }
@@ -201,11 +201,11 @@ For a valid request, the API will return a JSON response similar to:
 
 2. Plaid returns a public token to you.
 
-3. You will submit a public token to Plaid in exchange for an access token. 
+3. You will submit a public token to Plaid in exchange for an access token.
 
-4. You will submit access token to Plaid’s `/processor/token/create` endpoint and receive Processor Token (specific to Alpaca). 
+4. You will submit access token to Plaid’s `/processor/token/create` endpoint and receive Processor Token (specific to Alpaca).
 
-5. You will make a call to the processor endpoint to pass Alpaca the processor token, to initiate the payment. To pass the processor token use the ACH relationships endpoint (Link). 
+5. You will make a call to the processor endpoint to pass Alpaca the processor token, to initiate the payment. To pass the processor token use the ACH relationships endpoint (Link).
 
 #### Sample Request
 
@@ -231,9 +231,9 @@ For a valid request, the API will return a JSON response similar to:
 }
 ```
 
-6. Alpaca makes a call to Plaid to retrieve the Account and Routing number* using the processor token.  
+6. Alpaca makes a call to Plaid to retrieve the Account and Routing number* using the processor token.
 
-7. Alpaca saves the processor token and account and routing number internally for future use. Alpaca uses account information for NACHA file creation and processing. 
+7. Alpaca saves the processor token and account and routing number internally for future use. Alpaca uses account information for NACHA file creation and processing.
 
 *Can include Auth, Identity, Balance info - if the broker API wants to initiate a transfer, we use the transfer endpoint.
 

--- a/content/api-references/broker-api/trading/orders.md
+++ b/content/api-references/broker-api/trading/orders.md
@@ -198,7 +198,7 @@ Returns an [Order](/docs/resources/trading/orders/#the-order-object) object.
 
 `GET /v1/trading/accounts/{account_id}/orders`
 
-Retrieves a list of orders for the account, filtered by the supplied query parameters. Endpoint defaults to `open` orders if no parameters are provided. 
+Retrieves a list of orders for the account, filtered by the supplied query parameters. Endpoint defaults to `open` orders if no parameters are provided.
 
 ### Request
 

--- a/content/api-references/market-data-api/crypto-pricing-data/_index.md
+++ b/content/api-references/market-data-api/crypto-pricing-data/_index.md
@@ -13,7 +13,7 @@ Alpaca provides crypto data from multiple venues and does not route orders to al
 List of **crypto** exchanges which are supported by Alpaca.
 
 | Exchange Code | Name of Exchange      |
-| ------------- | --------------------- |     
+| ------------- | --------------------- |
 | ERSX          | ErisX                 |
 | GNSS          | Genesis               |
 | CBSE          | Coinbase              |
@@ -29,7 +29,7 @@ The Crypto Data API provides historical data through multiple endpoints. These e
 https://data.alpaca.markets/v1beta1/crypto
 ```
 
-This URL is the **same for both subscription plans**, there is no limitation 
+This URL is the **same for both subscription plans**, there is no limitation
 
 
 ### **Authentication**

--- a/content/api-references/market-data-api/crypto-pricing-data/realtime.md
+++ b/content/api-references/market-data-api/crypto-pricing-data/realtime.md
@@ -2,7 +2,7 @@
 title: Real-time Data
 weight: 120
 summary: Alpaca Crypto Data API provides websocket streaming for trades, quotes, minute bars and more. This helps receive the most up to date market information that could help your trading strategy to act upon certain market movements.
- 
+
 ---
 
 # Real-time Crypto Pricing Data
@@ -27,7 +27,7 @@ Both subscription plans provide the same source and level of crypto data, the on
 - There is no limit for the number of channels with minute bars (`bars`).
 
 
-**Unlimited plan:** 
+**Unlimited plan:**
 - One concurrent connection is allowed.
 - There is no limit for the number of channels at a time for trades, quotes and minute bars(`trades`,`quotes` and `bars`).
 
@@ -138,7 +138,7 @@ Much like `subscribe` you can also send an `unsubscribe` message that subtracts 
 
 ### Control messages
 
-You may receive the following control messages during your session. 
+You may receive the following control messages during your session.
 ```
 [{"T":"success","msg":"connected"}]
 ```

--- a/content/api-references/market-data-api/stock-pricing-data/_index.md
+++ b/content/api-references/market-data-api/stock-pricing-data/_index.md
@@ -33,7 +33,7 @@ Alpaca provides market data from two data sources:
 `wss://stream.data.alpaca.markets/v2/{source}`
 
 {{< hint info >}}
-**Broker API Businesses Sandbox Access**  
+**Broker API Businesses Sandbox Access**
 
 You can access the IEX market data with your Broker API key. This is free of charge and you can redistribute it to your end user without any additional agreement.
 

--- a/content/api-references/trading-api/account.md
+++ b/content/api-references/trading-api/account.md
@@ -14,7 +14,7 @@ engaging in any suspicious activity. Also, in accordance with FINRA's pattern da
 trading rule, an account may be flagged for pattern day trading
 (`pattern_day_trader flag`), which would inhibit an account from placing any
 further day-trades. Please note that cryptocurrencies are not eligible assets to be
-used as collateral for margin accounts and will require the asset be traded using 
+used as collateral for margin accounts and will require the asset be traded using
 cash only.
 
 
@@ -36,17 +36,17 @@ may get in `ACCOUNT_UPDATED` when personal information is being updated
 from the dashboard, in which case you may not be allowed trading for
 a short period of time until the change is approved.
 
-- `ONBOARDING`  
+- `ONBOARDING`
   The account is onboarding.
-- `SUBMISSION_FAILED`  
+- `SUBMISSION_FAILED`
   The account application submission failed for some reason.
-- `SUBMITTED`  
+- `SUBMITTED`
   The account application has been submitted for review.
-- `ACCOUNT_UPDATED`  
+- `ACCOUNT_UPDATED`
   The account information is being updated.
-- `APPROVAL_PENDING`  
+- `APPROVAL_PENDING`
   The final account approval is pending.
-- `ACTIVE`  
+- `ACTIVE`
   The account is active for trading.
-- `REJECTED`  
+- `REJECTED`
   The account application has been rejected.

--- a/content/broker/_index.md
+++ b/content/broker/_index.md
@@ -84,7 +84,7 @@ about how you can deposit funds into your customers accounts instantaneously
 
 Manage and keep track of all your business operations from our
 [Broker Dashboard](https://broker-app.alpaca.markets/sign-up). You can view almost
-everything on the Dashboard same as with our APIs. 
+everything on the Dashboard same as with our APIs.
 
 {{< /columns >}}
 

--- a/content/broker/get-started/_index.md
+++ b/content/broker/get-started/_index.md
@@ -9,12 +9,12 @@ summary: Open brokerage accounts, enable commission-free trading, and manage the
 
 This guide is going to help you set everything up in a sandbox environment to get you up and running with Broker API.
 
-The sandbox environment acts as a parallel environment where you can test our APIs safely without sending any real trades to the market. All prices, and execution times (i.e. market hours) hold true in sandbox and production. 
+The sandbox environment acts as a parallel environment where you can test our APIs safely without sending any real trades to the market. All prices, and execution times (i.e. market hours) hold true in sandbox and production.
 
-You can either follow the steps below to test specific calls within the broker dashboard or access the Postman collection to view and test all possible requests in one place. 
+You can either follow the steps below to test specific calls within the broker dashboard or access the Postman collection to view and test all possible requests in one place.
 
 ## **Postman Collection**
-To get started with the Broker API Postman Collection you can either access the [Alpaca Workspace](https://www.postman.com/alpacamarkets/workspace/alpaca-public-workspace/overview) on Postman to fork the collection or import the file below directly to your own workspace. 
+To get started with the Broker API Postman Collection you can either access the [Alpaca Workspace](https://www.postman.com/alpacamarkets/workspace/alpaca-public-workspace/overview) on Postman to fork the collection or import the file below directly to your own workspace.
 
 ### **Fork Broker API Collection on Postman**
 Refer to this [tutorial](https://alpaca.markets/learn/try-our-postman-workspace-for-alpaca-apis/) to learn how to fork the collection and sample environment and get started with making calls right away. We recommend following this method so your collection stays up to date with the changes we make to the API.
@@ -33,7 +33,7 @@ Refer to this [tutorial](https://alpaca.markets/learn/try-our-postman-workspace-
 4. Send one of the defined HTTP requests while the created environment is selected.
 
 ## **Testing on Broker Dashboard**
-Follow these steps to make API calls directly within the Broker Dashboard. 
+Follow these steps to make API calls directly within the Broker Dashboard.
 
 ### **0. Setting Up Broker API on Dashboard**
 

--- a/content/broker/ribbit/_index.md
+++ b/content/broker/ribbit/_index.md
@@ -9,10 +9,10 @@ aliases: [/ribbit/]
 # Ribbit
 
 ## What is Ribbit?
-Ribbit is a skeleton mobile app designed to showcase the capabilities of the Broker API. It's a fully functional trading application that demonstrates how users would interact with your product. It uses all the different functionality that the Broker API offers including onboarding new users, funding an account, managing market data, and handling trade activity. 
+Ribbit is a skeleton mobile app designed to showcase the capabilities of the Broker API. It's a fully functional trading application that demonstrates how users would interact with your product. It uses all the different functionality that the Broker API offers including onboarding new users, funding an account, managing market data, and handling trade activity.
 
 ## Example user experience
-The screenshots below demonstrate how a native user would walk through Ribbit to accomplish various tasks. 
+The screenshots below demonstrate how a native user would walk through Ribbit to accomplish various tasks.
 
 ### **Create a New Account**
 Once Ribbit users sign up with their email and create a password, it triggers the brokerage account onboarding process to begin. The following screens prompt users to input their information such as name, date of birth, tax ID, and more information that is required by law to open a brokerage account. At the end of this process, Ribbit calls the [Accounts API](https://alpaca.markets/docs/broker/api-references/accounts/accounts/) to submit all the information to Alpaca where we verify the information and approve the account application.
@@ -28,7 +28,7 @@ The next step for the new users is to deposit the money to start trading. Ribbit
 
 As a demo app, Ribbit uses the Plaid sandbox which simulates the production environment behavior. When you try the app, use `user_good` and `pass_good` for the credentials with any banks shown in the app. Alpaca’s sandbox where Ribbit simulates the ACH transactions and the virtual money is credited in the user’s account in a moment.
 
-Allowing your end users to connect to their personal bank and fund their account on your app can be intimidating if you aren’t familiar with the high level financial requirements and flows. Fortunately, our [Bank](https://alpaca.markets/docs/broker/api-references/funding/bank/#bank), [ACH Relationships](https://alpaca.markets/docs/broker/api-references/funding/ach/#ach-relationships-api), and [Transfers](https://alpaca.markets/docs/broker/api-references/funding/transfers/#transfers) APIs make it easy to achieve this! The Bank API lets you create, retrieve, and delete bank relationships between their personal bank and their account on your app. The ACH Relationships API deals with connecting, getting, and deleting your end user’s specific bank account that will be used to initiate and receive ACH transfers from your app. Finally, the Transfers API initiates, lists, and cancels the actual transfer initiated from your app on behalf of your end user. See how this flow is implemented from your user’s perspective below. 
+Allowing your end users to connect to their personal bank and fund their account on your app can be intimidating if you aren’t familiar with the high level financial requirements and flows. Fortunately, our [Bank](https://alpaca.markets/docs/broker/api-references/funding/bank/#bank), [ACH Relationships](https://alpaca.markets/docs/broker/api-references/funding/ach/#ach-relationships-api), and [Transfers](https://alpaca.markets/docs/broker/api-references/funding/transfers/#transfers) APIs make it easy to achieve this! The Bank API lets you create, retrieve, and delete bank relationships between their personal bank and their account on your app. The ACH Relationships API deals with connecting, getting, and deleting your end user’s specific bank account that will be used to initiate and receive ACH transfers from your app. Finally, the Transfers API initiates, lists, and cancels the actual transfer initiated from your app on behalf of your end user. See how this flow is implemented from your user’s perspective below.
 
 ![image](./demo_images/Ribbit_Funding.png)
 
@@ -46,12 +46,12 @@ The end user interacts with Ribbit’s UI to achieve a task while Ribbit’s bac
 
 ![image](./demo_images/Ribbit_Architecture.png)
 
-The backend application serves as a thin layer to proxy the API requests coming from the mobile app but makes sure each request is authorized for the appropriate user. 
+The backend application serves as a thin layer to proxy the API requests coming from the mobile app but makes sure each request is authorized for the appropriate user.
 
 ## Technology
-The user interface is written in Swift for iOS and Java for Android. The backend is implemented using Go. 
+The user interface is written in Swift for iOS and Java for Android. The backend is implemented using Go.
 ### Alpaca APIs
-All of the technology that is needed for users to interact with Ribbit's core functionality is acheived through the Broker API. Accessing information related to the market is gathered using the [Market Data API](https://alpaca.markets/docs/broker/market-data/). 
+All of the technology that is needed for users to interact with Ribbit's core functionality is acheived through the Broker API. Accessing information related to the market is gathered using the [Market Data API](https://alpaca.markets/docs/broker/market-data/).
 
 ## Where Can I Access the Source Code?
-The codebase is hosted on GitHub and separated into three different repositories for the implementation of the [backend](https://github.com/alpacahq/ribbit-backend), [iOS user interface](https://github.com/alpacahq/ribbit-ios), and [Android user interface](https://github.com/alpacahq/ribbit-android). 
+The codebase is hosted on GitHub and separated into three different repositories for the implementation of the [backend](https://github.com/alpacahq/ribbit-backend), [iOS user interface](https://github.com/alpacahq/ribbit-ios), and [Android user interface](https://github.com/alpacahq/ribbit-android).

--- a/content/market-data/_index.md
+++ b/content/market-data/_index.md
@@ -3,7 +3,7 @@ bookFlatSection: true
 bookCollapseSection: true
 weight: 4
 title: Market Data API
-summary: 
+summary:
 isTopNav: true
 topNavTitle: Market Data API
 topNavOrder: 3
@@ -11,7 +11,7 @@ topNavOrder: 3
 
 # Market Data API
 
-Access real-time and up to 6+ years of historical equities & crypto data. 
+Access real-time and up to 6+ years of historical equities & crypto data.
 
 ---
 
@@ -54,10 +54,10 @@ The Free plan is included in both paper-only and live trading accounts as the de
 
 The **Free plan** consists of data from IEX (Investors Exchange LLC).
 
-For the **Unlimited plan**, we receive direct feeds from the CTA (administered by NYSE) and UTP (administered by Nasdaq) SIPs. These 2 feeds combined offer 100% market volume. 
+For the **Unlimited plan**, we receive direct feeds from the CTA (administered by NYSE) and UTP (administered by Nasdaq) SIPs. These 2 feeds combined offer 100% market volume.
 
 {{< hint info >}}
-**For Broker API Businesses**  
+**For Broker API Businesses**
 We provide separate pricing or Broker API partners looking to leverage market data. For more information, please contact us.
 {{< /hint >}}
 
@@ -95,13 +95,13 @@ The tape id of each exchange is returned in all market data requests. You can us
 
 ## Conditions
 
-Each feed/exchange uses its own set of codes to identify trade and quote conditions, so the same condition may have a different code depending on the originator of the data. 
+Each feed/exchange uses its own set of codes to identify trade and quote conditions, so the same condition may have a different code depending on the originator of the data.
 
 ### Trade conditions
 
 ### CTS
 
-The table below shows codes that denotes a particular condition applicable to the trade from the CTA Plan. 
+The table below shows codes that denotes a particular condition applicable to the trade from the CTA Plan.
 
 For more information, see page 64 of the [Consolidated Tape System (CTS) Specification](https://www.ctaplan.com/publicdocs/ctaplan/CTS_Pillar_Output_Specification.pdf).
 
@@ -125,7 +125,7 @@ For more information, see page 64 of the [Consolidated Tape System (CTS) Specifi
 
 ### UTDF
 
-The table below shows condition codes from the UTP Plan. 
+The table below shows condition codes from the UTP Plan.
 
 For more information, see page 43 of the [UTP Specification](https://www.utpplan.com/DOC/UtpBinaryOutputSpec.pdf#page=43).
 
@@ -155,7 +155,7 @@ For more information, see page 43 of the [UTP Specification](https://www.utpplan
 
 ### CQS
 
-The table below shows codes that denotes a particular condition applicable to a quote from the CTA Plan. 
+The table below shows codes that denotes a particular condition applicable to a quote from the CTA Plan.
 
 For more information, see Appendix G of the [CQS Specification](https://www.ctaplan.com/publicdocs/ctaplan/CQS_Pillar_Output_Specification.pdf).
 

--- a/content/oauth/_index.md
+++ b/content/oauth/_index.md
@@ -11,7 +11,7 @@ topNavOrder: 4
 
 # OAuth Apps
 
-Develop applications on Alpaca's platform using OAuth2. Alpaca's OAuth allows you to seamlessly integrate financial markets into your application and expand your audience to the over 100K brokerage accounts on Alpaca's platform. Read [Register Your App]({{< relref "registration" >}}) to learn how you can register your app. In addition, you can visit [OAuth Integration Guide]({{< relref "guide" >}}) to learn more about using OAuth to connect your applications with Alpaca. 
+Develop applications on Alpaca's platform using OAuth2. Alpaca's OAuth allows you to seamlessly integrate financial markets into your application and expand your audience to the over 100K brokerage accounts on Alpaca's platform. Read [Register Your App]({{< relref "registration" >}}) to learn how you can register your app. In addition, you can visit [OAuth Integration Guide]({{< relref "guide" >}}) to learn more about using OAuth to connect your applications with Alpaca.
 
 ## Broker Partners
 
@@ -33,7 +33,7 @@ Broker partners are able to create their own OAuth service. Allow your end users
 
 
 - **Q: What can an OAuth app do?**
-- A: OAuth allows you to manage your end-user's Alpaca brokerage account on their behalf. This means you can create many types of financial services including automated investing, portfolio analytics and much more. 
+- A: OAuth allows you to manage your end-user's Alpaca brokerage account on their behalf. This means you can create many types of financial services including automated investing, portfolio analytics and much more.
 
 
 ----
@@ -44,18 +44,18 @@ Broker partners are able to create their own OAuth service. Allow your end users
 ----
 
 - **Q: How secure is OAuth?**
-- A: OAuth2 itself is very secure. However you must make sure to follow good practices in how you handle tokens. Make sure to never publicly expose your client secret and access tokens. Learn more in the [API reference]({{< relref "../api-references/oauth-api/_index.md" >}}). 
+- A: OAuth2 itself is very secure. However you must make sure to follow good practices in how you handle tokens. Make sure to never publicly expose your client secret and access tokens. Learn more in the [API reference]({{< relref "../api-references/oauth-api/_index.md" >}}).
 
 ----
 
 - **Q: How to get OAuth App live?**
-- A: You will need to register your app in the OAuth apps section of the dashboard. Learn more about [Register Your App]({{< relref "./registration.md" >}}). 
+- A: You will need to register your app in the OAuth apps section of the dashboard. Learn more about [Register Your App]({{< relref "./registration.md" >}}).
 
 ----
 
-- **Q: I’m developing an app/service targeting non-US users. Can we integrate with Alpaca’s OAuth API?** 
-- A: Alpaca's platform supports brokerage accounts for international users. When you build an app on OAuth, all users on Alpaca's platform will be able to use your service, including international users. 
-  
+- **Q: I’m developing an app/service targeting non-US users. Can we integrate with Alpaca’s OAuth API?**
+- A: Alpaca's platform supports brokerage accounts for international users. When you build an app on OAuth, all users on Alpaca's platform will be able to use your service, including international users.
 
-  
+
+
 

--- a/content/oauth/registration.md
+++ b/content/oauth/registration.md
@@ -7,7 +7,7 @@ summary: How to register your OAuth app
 
 # Register your OAuth app
 
-Before integrating with Alpaca, you'll first need to create a new OAuth app under your [OAuth Apps](https://app.alpaca.markets/brokerage/apps/manage) page. The OAuth Apps page is accessible from the dashboard, which requires you to login to your Alpaca brokerage account to visit. 
+Before integrating with Alpaca, you'll first need to create a new OAuth app under your [OAuth Apps](https://app.alpaca.markets/brokerage/apps/manage) page. The OAuth Apps page is accessible from the dashboard, which requires you to login to your Alpaca brokerage account to visit.
 
 ### Visit OAuth apps on dashboard
 

--- a/content/oauth/supported-apps/blueshift.md
+++ b/content/oauth/supported-apps/blueshift.md
@@ -1,6 +1,6 @@
 ---
 title: Blueshift
-weight: 40 
+weight: 40
 description: Using Blueshift, you can write trading algorithms with your web browser and run backtesting, and convert it to a live trading algorithm.
 ---
 

--- a/content/oauth/supported-apps/predictnow.md
+++ b/content/oauth/supported-apps/predictnow.md
@@ -7,39 +7,39 @@ weight: 70
 
 ## How It Works
 
-### What is PredictNow.Ai? 
+### What is PredictNow.Ai?
 
 PredictNow.ai is a no-code machine learning SaaS based in Toronto, Canada that is primarily focused on helping traders apply machine learning to their investment strategies in order to predict the profitability of their next trade. PredictNow.ai can calculate the most important input variables groups (also known as “clusters”) that empower a user’s prediction and only incorporate those in the prediction decision.
 
 Users have to train a machine learning model based on their historical results, where they receive predictive performance results for both the in-sample and out-of-sample datasets. This trained model is then downloaded and is used in the Live section. In the Live section, users upload the model file along with the data features for that day into the PredictNow.ai software. The software then utilizes the previously trained model to provide a prediction for the daily dataset. We also provide access to a Rest API, allowing the user to directly implement the PredictNow.ai software into their internal processes.
 
-This no-code process can help traders predict the profitability of their trades and help improve their existing trading strategies. 
+This no-code process can help traders predict the profitability of their trades and help improve their existing trading strategies.
 
 
 ### How to sign up for PredictNow.Ai and link an Alpaca brokerage account?
 
-If you are an existing Alpaca user linking to PredictNow.ai is quite simple. Go to the PredictNow.ai website and sign up for an account. You can initially get full access through a 30-day free trial. Once this is done on the PredictNow platform you will see an option to sign in to Alpaca. 
+If you are an existing Alpaca user linking to PredictNow.ai is quite simple. Go to the PredictNow.ai website and sign up for an account. You can initially get full access through a 30-day free trial. Once this is done on the PredictNow platform you will see an option to sign in to Alpaca.
 
 {{< safe-html >}}
 <center><img src="./PredictNow-Alpaca.png" width="80%"></center>
 {{< /safe-html >}}
 
 
-As soon as you’re logged in you will receive an authentication page asking for your permission to allow PredictNow to access the relevant information. As soon as you click to allow it will take you back to the train mode page on PredictNow.Ai. 
+As soon as you’re logged in you will receive an authentication page asking for your permission to allow PredictNow to access the relevant information. As soon as you click to allow it will take you back to the train mode page on PredictNow.Ai.
 
 
-### How to use PredictNow.Ai with Alpaca Data? 
+### How to use PredictNow.Ai with Alpaca Data?
 
-Once you’ve given permission to the PredictNow.ai platform your brokerage data can be directly imported from Alpaca to PredictNow.ai. 
+Once you’ve given permission to the PredictNow.ai platform your brokerage data can be directly imported from Alpaca to PredictNow.ai.
 
-PredictNow.ai currently offers Alpaca users two Profit and Loss or PNL modes to choose from. 
+PredictNow.ai currently offers Alpaca users two Profit and Loss or PNL modes to choose from.
 One is the round-trip PnL. A round trip would basically be taking a long version and selling it or taking a short version and buying it later. For each of the entries for the realized round-trip PnL, the associated timestamp is the trade entry timestamp. The second PnL is the MTM or mark to market is basically one entry for each business day and this illustrates the change in NAV on a day-to-day basis.
 
-Users will first work in train mode to create a model using training data and once the model is complete and you are satisfied with probability analysis you can go ahead and download the model and upload it into the live mode. 
+Users will first work in train mode to create a model using training data and once the model is complete and you are satisfied with probability analysis you can go ahead and download the model and upload it into the live mode.
 
 Below is a demo which walks you through how to link your Alpaca data to PredictNow and how to train and use the live modes. This demo will also go into detail regarding which results are relevant and what specific data sheets indicate.
 
-{{< youtube nP9gef7ErRw >}} 
+{{< youtube nP9gef7ErRw >}}
 
-If you have any questions or trouble setting up, please do not hesitate to reach out to us at **info@predictnow.ai**. Our team also offers professional consulting services and is happy to guide you through setting up a successful model to further improve your trading strategy.  
+If you have any questions or trouble setting up, please do not hesitate to reach out to us at **info@predictnow.ai**. Our team also offers professional consulting services and is happy to guide you through setting up a successful model to further improve your trading strategy.
 

--- a/content/trading/crypto-trading.md
+++ b/content/trading/crypto-trading.md
@@ -7,7 +7,7 @@ aliases:
 
 # Crypto Trading
 
-We now offer crypto trading through our API and the Alpaca web dashboard! Trade all day, seven days a week, as frequently as you'd like. 
+We now offer crypto trading through our API and the Alpaca web dashboard! Trade all day, seven days a week, as frequently as you'd like.
 
 {{< note title="Crypto trading is currently in open beta!" >}}
 
@@ -52,7 +52,7 @@ When submitting crypto orders through the [Orders API]({{< relref "../api-refere
 `time_in_force` values are `day`, `gtc`, `ioc`, and `fok`. We accept fractional
 orders as well with either `notional` or `qty` provided.
 
-Learn more about [orders]({{< relref "/trading/orders.md" >}}) and [fractional trading]({{< relref "/trading/fractional-trading.md" >}}). 
+Learn more about [orders]({{< relref "/trading/orders.md" >}}) and [fractional trading]({{< relref "/trading/fractional-trading.md" >}}).
 
 All cryptocurrency assets are fractionable but the supported decimal points vary depending on the cryptocurrency.
 

--- a/content/trading/margin-and-shorting.md
+++ b/content/trading/margin-and-shorting.md
@@ -91,7 +91,7 @@ power for intraday trading without any cost.
 Alpaca currently **only** supports **opening** short positions in easy to borrow (“ETB”) securities. **Any open short order
 in a stock that changes from ETB to HTB overnight will be automatically cancelled prior to market open**.
 
-Alpaca passes through all borrow costs incurred when a customer shorts a stock. Borrow fees accrue 
+Alpaca passes through all borrow costs incurred when a customer shorts a stock. Borrow fees accrue
 daily and are billed at the end of each month. Borrow fees can vary significantly depending upon demand to short.
 Generally, ETBs cost between 30 and 300bps annually.
 
@@ -101,7 +101,7 @@ vice versa.
 
 While we do not currently support opening short positions in hard to borrow (“HTB”) securities, we will not
 force you to close out a position in a stock that has gone from ETB to HTB unless the lender has called the stock.
-If a stock you hold short has gone from ETB to HTB, you will incur a higher daily stock borrow fee for that stock. 
+If a stock you hold short has gone from ETB to HTB, you will incur a higher daily stock borrow fee for that stock.
 We do not currently provide HTB rates via our API, so please contact us in these cases.
 
 Daily stock borrow fees are the fees incurred for all ETB shorts held in your account as of end of day plus any
@@ -119,4 +119,4 @@ And
 
 Please note that if you hold short positions as of a Friday settlement date, you will incur stock borrow fees for 3 days (Friday, Saturday and Sunday).
 
-Stock borrow fees are charged in the nearest round lot (100 shares) regardless of how many shares were actually shorted. This is because stocks are borrowed in round lots. 
+Stock borrow fees are charged in the nearest round lot (100 shares) regardless of how many shares were actually shorted. This is because stocks are borrowed in round lots.

--- a/content/trading/orders.md
+++ b/content/trading/orders.md
@@ -43,7 +43,7 @@ your available buying power. If you then submitted another order with an order v
 Orders not eligible for extended hours submitted between 4:00pm - 7:00pm ET
 will be **rejected**.
 
-Orders not eligible for extended hours submitted after 7:00pm ET 
+Orders not eligible for extended hours submitted after 7:00pm ET
 will be queued and eligible for execution at the time of the next market open.
 
 Orders eligible for extended hours submitted outside of 9:00am - 6:00pm ET are handled as described in the section below.
@@ -94,7 +94,7 @@ If this is done you will see the following error message:
 `"unable to open new notional orders while having open closing position orders"`
 
 All symbols supported during regular market hours are also supported during extended hours. Short selling is also
-treated the same. 
+treated the same.
 
 ## Order Types
 When you submit an order, you can choose one of supported order types.
@@ -144,9 +144,9 @@ The thresholds are doubled during pre-market and after-hours.
 ### Stop Order
 A stop (market) order is an order to buy or sell a security when its price moves past
 a particular point, ensuring a higher probability of achieving a predetermined
-entry or exit price. Once the order is elected, the stop order becomes a market order. 
-Alpaca converts buy stop orders into stop limit orders with a limit price that is 4% higher 
-than a stop price < $50 (or 2.5% higher than a stop price >= $50). Sell stop orders are 
+entry or exit price. Once the order is elected, the stop order becomes a market order.
+Alpaca converts buy stop orders into stop limit orders with a limit price that is 4% higher
+than a stop price < $50 (or 2.5% higher than a stop price >= $50). Sell stop orders are
 **not** converted into stop limit orders.
 
 A stop order does not guarantee the order will be filled at a certain price
@@ -181,8 +181,8 @@ completely filled, two conditional exit orders are activated. One of the two
 closing orders is called a take-profit order, which is a limit order, and the
 other is called a stop-loss order, which is either a stop or stop-limit order.
 Importantly, only one of the two exit orders can be executed. Once one of the
-exit orders is filled, the other is canceled. Please note, however, that in 
-extremely volatile and fast market conditions, both orders may fill before the 
+exit orders is filled, the other is canceled. Please note, however, that in
+extremely volatile and fast market conditions, both orders may fill before the
 cancellation occurs.
 
 Without a bracket order, you would not be able to submit both entry and exit
@@ -342,9 +342,9 @@ high water mark. Once the stop price is triggered, the order turns into a market
 it may fill above or below the stop trigger price.
 
 To submit a trailing stop order, you will set the `type` parameter to "trailing_stop". There are two order submission parameters related to trailing stop, one of which is required when `type` is "trailing_stop".
-- `trail_price`: string&lt;number&gt;  
+- `trail_price`: string&lt;number&gt;
   a dollar value away from the highest water mark. If you set this to 2.00 for a sell trailing stop, the stop price is always `hwm - 2.00`.
-- `trail_percent`: string&lt;number&gt;  
+- `trail_percent`: string&lt;number&gt;
   a percent value away from the highest water mark. If you set this to 1.0 for a sell trailing stop, the stop price is always `hwm * 0.99`.
 
 One of these values must be set for trailing stop orders. The following is an example of trailing order submission JSON parameter.
@@ -362,18 +362,18 @@ One of these values must be set for trailing stop orders. The following is an ex
 
 The Order entity returned from the GET method has a few fields related to trailing stop orders.
 
-- `trail_price`: string&lt;number&gt;  
+- `trail_price`: string&lt;number&gt;
   This is the same value as specified when the order was submitted. It will be null if this was not specified.
-- `trail_percent`: string&lt;number&gt;  
+- `trail_percent`: string&lt;number&gt;
   This is the same value as specified when the order was submitted. It will be null if this was not specified.
-- `hwm`: string&lt;number&gt;  
+- `hwm`: string&lt;number&gt;
   The high water mark value. This continuously changes as the market moves towards your favorable way.
-- `stop_price`: string&lt;number&gt;  
+- `stop_price`: string&lt;number&gt;
   This is the same as stop price in the regular stop/stop limit orders, but this is derived from hwm and trail parameter, and continuously updates as hwm changes.
 
 If a trailing stop order is accepted, the order status becomes "new". While the order is pending stop price trigger, you can update the trail parameter by the PATCH method.
 
-- `trail`: string&lt;number&gt;  
+- `trail`: string&lt;number&gt;
   The new value of the `trail_price` or `trail_percent` value. Such a replace request is effective only for the order type is "trailing_stop" before the stop price is hit. Note, you cannot change the price trailing to the percent trailing or vice versa.
 
 Here are some details of trailing stop.
@@ -382,40 +382,40 @@ Here are some details of trailing stop.
 - Valid time-in-force values for trailing stop are "day" and "gtc".
 - Trailing stop orders are currently supported only with single orders. However, we plan to support trailing stop as the stop loss leg of bracket/OCO orders in the future.
 
-Proper use of Trailing Stop orders requires understanding the purpose and how they operate. The primary point to keep in mind with Trailing Stop orders is to ensure the difference between the trailing stop and the price is big enough that typical price fluctuations do not trigger a premature execution. 
+Proper use of Trailing Stop orders requires understanding the purpose and how they operate. The primary point to keep in mind with Trailing Stop orders is to ensure the difference between the trailing stop and the price is big enough that typical price fluctuations do not trigger a premature execution.
 
-In fast moving markets, the execution price may be less favorable than the stop price. The potential for such vulnerability increases for GTC orders across trading sessions or stocks experiencing trading halts. The stop price triggers a market order and therefore, it is not necessarily the case that the stop price will be the same as the execution price. 
+In fast moving markets, the execution price may be less favorable than the stop price. The potential for such vulnerability increases for GTC orders across trading sessions or stocks experiencing trading halts. The stop price triggers a market order and therefore, it is not necessarily the case that the stop price will be the same as the execution price.
 
 With regard to stock splits, Alpaca reserves the right to cancel or adjust pricing and/or share quantities of trailing stop orders based upon its own discretion. Since Alpaca relies on third parties for market data, corporate actions or incorrect price data may cause a trailing stop to be triggered prematurely.
 
 ## Time in Force
 
-  **Note:** For Crypto Trading, Alpaca supports the following Time-In-Force designations: `day`, `gtc`, `ioc` and `fok`. OPG and CLS are not supported. 
-  
+  **Note:** For Crypto Trading, Alpaca supports the following Time-In-Force designations: `day`, `gtc`, `ioc` and `fok`. OPG and CLS are not supported.
+
 Alpaca supports the following Time-In-Force designations:
 
-- `day`  
+- `day`
   A day order is eligible for execution only on the day it is live. By default, the order is only valid
   during Regular Trading Hours (9:30am - 4:00pm ET). If unfilled after the closing auction, it is automatically canceled.
   If submitted after the close, it is queued and submitted the following trading day.
   However, if marked as eligible for extended hours, the order can also execute during supported extended hours.
-- `gtc`  
+- `gtc`
   The order is good until canceled. Non-marketable GTC limit orders are subject to price adjustments to offset corporate
   actions affecting the issue. We do not currently support Do Not Reduce(DNR) orders to opt out of such price adjustments.
-- `opg`  
+- `opg`
   Use this TIF with a market/limit order type to submit "market on open" (MOO) and "limit on open" (LOO) orders.
   This order is eligible to execute only in the market opening auction. Any unfilled orders after the open will be cancelled. OPG orders submitted after 9:28am but before 7:00pm ET will be rejected. OPG orders submitted after 7:00pm will be queued and routed to the following day's opening auction.<br><br>
   On open/on close orders are routed to the primary exchange. Such orders do not necessarily execute exactly at 9:30am / 4:00pm ET but execute per the exchange’s auction rules.
-- `cls`  
+- `cls`
   Use this TIF with a market/limit order type to submit "market on close" (MOC) and "limit on close" (LOC) orders.
   This order is eligible to execute only in the market closing auction. Any unfilled orders after the close will be cancelled.
   CLS orders submitted after 3:50pm but before 7:00pm ET will be rejected. CLS orders submitted after 7:00pm will be queued
   and routed to the following day's closing auction. Only available with API v2.
-- `ioc`  
+- `ioc`
   An Immediate Or Cancel (IOC) order requires all or part of the order to be executed immediately. Any unfilled
   portion of the order is canceled. Only available with API v2.
-  Most market makers who receive IOC orders will attempt to fill the order on a principal basis only, and cancel any unfilled balance. On occasion, this can result in the entire order being cancelled if the market maker does not have any existing inventory of the security in question. 
-- `fok`  
+  Most market makers who receive IOC orders will attempt to fill the order on a principal basis only, and cancel any unfilled balance. On occasion, this can result in the entire order being cancelled if the market maker does not have any existing inventory of the security in question.
+- `fok`
   A Fill or Kill (FOK) order is only executed if the entire order quantity can be filled, otherwise the order is canceled.
   Only available with API v2.
 
@@ -424,52 +424,52 @@ Alpaca supports the following Time-In-Force designations:
 An order executed through Alpaca can experience several status changes
 during its lifecycle. The most common statuses are described in detail below:
 
-- `new`  
+- `new`
    The order has been received by Alpaca, and routed to exchanges for execution.
    This is the usual initial state of an order.
-- `partially_filled`  
+- `partially_filled`
    The order has been partially filled.
-- `filled`  
+- `filled`
    The order has been filled, and no further updates will occur for the order.
-- `done_for_day`  
+- `done_for_day`
    The order is done executing for the day, and will not receive further
    updates until the next trading day.
-- `canceled`  
+- `canceled`
    The order has been canceled, and no further updates will occur for
    the order. This can be either due to a cancel request by the user, or
    the order has been canceled by the exchanges due to its time-in-force.
-- `expired`  
+- `expired`
    The order has expired, and no further updates will occur for the order.
-- `replaced`  
+- `replaced`
    The order was replaced by another order, or was updated due to a market event such as corporate action.
-- `pending_cancel`  
+- `pending_cancel`
    The order is waiting to be canceled.
-- `pending_replace`  
+- `pending_replace`
    The order is waiting to be replaced by another order. The order will reject cancel request while in this state.
 
 Less common states are described below. Note that these states only occur
 on very rare occasions, and most users will likely never see their
 orders reach these states:
 
-- `accepted`  
+- `accepted`
    The order has been received by Alpaca, but hasn't yet been routed to
    the execution venue. This could be seen often out side of trading session hours.
-- `pending_new`  
+- `pending_new`
    The order has been received by Alpaca, and routed to the exchanges,
    but has not yet been accepted for execution. This state only occurs on rare occasions.
-- `accepted_for_bidding`  
+- `accepted_for_bidding`
    The order has been received by exchanges, and is evaluated for pricing.
    This state only occurs on rare occasions.
-- `stopped`  
+- `stopped`
    The order has been stopped, and a trade is guaranteed for the order,
    usually at a stated price or better, but has not yet occurred. This state only occurs on rare occasions.
-- `rejected`  
+- `rejected`
    The order has been rejected, and no further updates will occur for
    the order. This state occurs on rare occasions and may occur based on various conditions decided by the exchanges.
-- `suspended`  
+- `suspended`
    The order has been suspended, and is not eligible for trading. This
    state only occurs on rare occasions.
-- `calculated`  
+- `calculated`
    The order has been completed for the day (either filled or done for day),
    but remaining settlement calculations are still pending. This state only
    occurs on rare occasions.
@@ -478,25 +478,25 @@ An order may be canceled through the API up until the point it reaches
 a state of either `filled`, `canceled`, or `expired`.
 
 ## Odd Lots and Block Trades
-When trading stocks, a round lot is typically defined as 100 shares, or a larger number that can be evenly divided by 100. An odd lot is anything that cannot be evenly divided by 100 shares (e.g. 48, 160, etc.). A block trade is typically defined as a trade that involves 10,000 shares or more.  
+When trading stocks, a round lot is typically defined as 100 shares, or a larger number that can be evenly divided by 100. An odd lot is anything that cannot be evenly divided by 100 shares (e.g. 48, 160, etc.). A block trade is typically defined as a trade that involves 10,000 shares or more.
 
 
-For trading purposes, odd lots are typically treated like round lots. However, regulatory trading rules allow odd lots to be treated differently. Similarly, block trades are usually broken up for execution and may take longer to execute due to the market having to absorb the block of shares over time rather than in one large execution. When combined with a thinly traded stock, it’s quite possible that odd lots and block trades may not get filled or execute in a timely manner, and sometimes, not at all, depending on other factors like order types used. 
+For trading purposes, odd lots are typically treated like round lots. However, regulatory trading rules allow odd lots to be treated differently. Similarly, block trades are usually broken up for execution and may take longer to execute due to the market having to absorb the block of shares over time rather than in one large execution. When combined with a thinly traded stock, it’s quite possible that odd lots and block trades may not get filled or execute in a timely manner, and sometimes, not at all, depending on other factors like order types used.
 
 ## Short Sales
-A short sale is the sale of a stock that a seller does not own. In general, a short seller sells borrowed stock in anticipation of a price decline. The short seller later closes out the position by purchasing the stock. By rule, short sales cannot be placed on a downtick in the market price of the stock. This rule also applies when markets close. When a stock closes on a downtick, short sale orders will not be filled. 
+A short sale is the sale of a stock that a seller does not own. In general, a short seller sells borrowed stock in anticipation of a price decline. The short seller later closes out the position by purchasing the stock. By rule, short sales cannot be placed on a downtick in the market price of the stock. This rule also applies when markets close. When a stock closes on a downtick, short sale orders will not be filled.
 
 ## Order Handling Standards at Alpaca Securities LLC
 Market and limit order orders are protected on the primary exchange opening print.  We do not necessarily route retail orders to the exchange, but will route orders to market makers who will route orders on your behalf to the primary market opening auction.  This protection is subject to exchange time cutoff for each exchange’s opening process.  For instance, if you enter a market order between 9:28:01 and 9:29:59 on a Nasdaq security you would not receive the Nasdaq Official Opening Price (NOOP) since Nasdaq has a cutoff of 9:28 for market orders to be sent to the cross. Any market orders received before 9:28 will be filled at the Nasdaq Official Opening Price.
 
 
-Stop orders and trailing stops are elected on the consolidated print.  Your stop order will only elect if there is a trade on the consolidated tape at or lower than your stop price and provided the electing trade is not outside of the NBBO.  
+Stop orders and trailing stops are elected on the consolidated print.  Your stop order will only elect if there is a trade on the consolidated tape at or lower than your stop price and provided the electing trade is not outside of the NBBO.
 
 
 Limit Orders are generally subject to limit order display and protection.  Protection implies that you should not see the stock trade better than your limit without you receiving an execution. Limit Order Display is bound by REG NMS Rule 611.  Your orders will be displayed if they are the National Best Bid or Best Offer excluding exceptions outlined REG NMS Rule 611. Some examples are listed below:
-- An odd lot order (under a unit of trade).  Most NMS securities have a unit of trade of 100 shares.    
-- Block Order.  A block order under REG NMS is designated as an order of at least 10,000 shares or at least $200,000 notional.  
+- An odd lot order (under a unit of trade).  Most NMS securities have a unit of trade of 100 shares.
+- Block Order.  A block order under REG NMS is designated as an order of at least 10,000 shares or at least $200,000 notional.
 - An “all or none” order
-- The client requests the order to not be displayed.  
-- Not Held orders   
+- The client requests the order to not be displayed.
+- Not Held orders
 

--- a/content/trading/paper-trading.md
+++ b/content/trading/paper-trading.md
@@ -96,4 +96,4 @@ a fill for an order that is much larger than the actual available liquidity.
 - When orders are eligible to be filled, they will receive partial fills for a random size 10% of the time. If
 the order price is still marketable, the remaining quantity would be re-evaluated for a subsequent fill.
 - Regardless of whether you have a Paper Trading Only account or a real money brokerage account,
-all orders submitted in paper trading will be matched against the best available current market price (NBBO).  
+all orders submitted in paper trading will be matched against the best available current market price (NBBO).

--- a/content/trading/user-protections.md
+++ b/content/trading/user-protections.md
@@ -119,8 +119,8 @@ One of the two protections will be enabled for all users (you cannot have both p
 We are working towards features to allow users to change their DTMC protection setting on their own without support help.
 
 
-### Equity/Order Ratio Validation Check  
-In order to help Alpaca Brokerage Account customers from placing orders larger than the calculated buying power, Alpaca has instituted a control on the account independent of the buying power for the account.  Alpaca will restrict the account to closing transactions when an account has a position that is 600% larger than the equity in the account.  The account will remain restricted for closing transactions until a member of Alpaca’s trading team reviews the account.  The trading team will either clear the alert by allowing opening transactions or will notify the client of the restriction and take corrective actions as necessary. 
+### Equity/Order Ratio Validation Check
+In order to help Alpaca Brokerage Account customers from placing orders larger than the calculated buying power, Alpaca has instituted a control on the account independent of the buying power for the account.  Alpaca will restrict the account to closing transactions when an account has a position that is 600% larger than the equity in the account.  The account will remain restricted for closing transactions until a member of Alpaca’s trading team reviews the account.  The trading team will either clear the alert by allowing opening transactions or will notify the client of the restriction and take corrective actions as necessary.
 
 
 ### Paper Trading

--- a/data/webapi/endpoints/bars-v2.yaml
+++ b/data/webapi/endpoints/bars-v2.yaml
@@ -1,7 +1,7 @@
 endpoints:
   /v2/stocks/{symbol}/bars:
     GET:
-      title: Returns bars for the queried stock symbol 
+      title: Returns bars for the queried stock symbol
       summary: |
         This endpoint returns aggregate historical data for the requested security.
       params:

--- a/data/webapi/endpoints/crypto-trades.yaml
+++ b/data/webapi/endpoints/crypto-trades.yaml
@@ -3,7 +3,7 @@ endpoints:
     GET:
       title: Returns trades for the queried crypto symbol
       summary: |
-        This endpoint returns trade historical data for the requested crypto symbol. 
+        This endpoint returns trade historical data for the requested crypto symbol.
       params:
         path:
           - name: symbol

--- a/data/webapi/endpoints/latest-trade-v2.yaml
+++ b/data/webapi/endpoints/latest-trade-v2.yaml
@@ -1,9 +1,9 @@
 endpoints:
   /v2/stocks/{symbol}/trades/latest:
     GET:
-      title: Returns latest trade for the queried stock symbol 
+      title: Returns latest trade for the queried stock symbol
       summary: |
-        This endpoint returns latest trade for the requested security. 
+        This endpoint returns latest trade for the requested security.
       params:
         path:
           - name: symbol

--- a/data/webapi/endpoints/oauth.yaml
+++ b/data/webapi/endpoints/oauth.yaml
@@ -4,8 +4,8 @@ endpoints:
       title: Redirect user for authorization
       summary: |
         Redirect your user from your application to this endpoint
-        with the following query parameters. 
-        
+        with the following query parameters.
+
         Use the following base URL: `https://app.alpaca.markets`.
 
         Example Request URL: `https://app.alpaca.markets/oauth/authorize?response_type=code&client_id=YOUR_CLIENT_ID&redirect_uri=YOUR_REDIRECT_URL&state=SOMETHING_RANDOM&scope=account:write%20trading`
@@ -25,7 +25,7 @@ endpoints:
             type: string
             required: true
             desc: |
-              The URL where the user will be sent after authorization. 
+              The URL where the user will be sent after authorization.
               It must match one of the whitelisted redirect URIs for your application.
           - name: state
             type: string
@@ -41,8 +41,8 @@ endpoints:
     POST:
       title: Retrieve an access token
       summary: |
-        Exchange your temporary code for an access token. 
-        
+        Exchange your temporary code for an access token.
+
         Use the following base URL: `https://api.alpaca.markets`.
       params:
         body:

--- a/data/webapi/endpoints/snapshot-multiple-tickers-v2.yaml
+++ b/data/webapi/endpoints/snapshot-multiple-tickers-v2.yaml
@@ -3,7 +3,7 @@ endpoints:
     GET:
       title: Returns the snapshots for the queried stock symbols
       summary: |
-        This endpoint returns the snapshots for the requested securities. 
+        This endpoint returns the snapshots for the requested securities.
       params:
         query:
           - name: symbols

--- a/data/webapi/endpoints/trades-v2.yaml
+++ b/data/webapi/endpoints/trades-v2.yaml
@@ -1,9 +1,9 @@
 endpoints:
   /v2/stocks/{symbol}/trades:
     GET:
-      title: Returns trades for the queried stock symbol 
+      title: Returns trades for the queried stock symbol
       summary: |
-        This endpoint returns trade historical data for the requested security. 
+        This endpoint returns trade historical data for the requested security.
       params:
         path:
           - name: symbol

--- a/data/webapi/entities/crypto-latest-trade.yaml
+++ b/data/webapi/entities/crypto-latest-trade.yaml
@@ -6,7 +6,7 @@ spec:
   - name: x
     type: string
     required: true
-    desc: Exchange where the trade happened. 
+    desc: Exchange where the trade happened.
   - name: p
     type: number
     required: true

--- a/data/webapi/entities/crypto-trades.yaml
+++ b/data/webapi/entities/crypto-trades.yaml
@@ -6,7 +6,7 @@ spec:
   - name: x
     type: string
     required: true
-    desc: Exchange where the trade happened. 
+    desc: Exchange where the trade happened.
   - name: p
     type: number
     required: true

--- a/data/webapi/entities/latest-trade-v2.yaml
+++ b/data/webapi/entities/latest-trade-v2.yaml
@@ -6,7 +6,7 @@ spec:
   - name: x
     type: string
     required: true
-    desc: Exchange where the trade happened. 
+    desc: Exchange where the trade happened.
   - name: p
     type: number
     required: true

--- a/data/webapi/entities/trades-v2-item.yaml
+++ b/data/webapi/entities/trades-v2-item.yaml
@@ -6,7 +6,7 @@ spec:
   - name: x
     type: string
     required: true
-    desc: Exchange where the trade happened. 
+    desc: Exchange where the trade happened.
   - name: p
     type: number
     required: true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -22,7 +22,7 @@
     </header>
 
     <div class="book-page">
-      
+
 
       {{ partial "docs/inject/content-before" . }}
       {{ template "main" . }} <!-- Page Content -->
@@ -52,7 +52,7 @@
   {{/* Adds Cookie Banner, and injects Hubspot Tracking. Tracking is only applied to routes specified in TRACKING_ROUTES */}}
   <script type="text/javascript">
     // Small cookies helper https://github.com/js-cookie/js-cookie
-    !function(e){var n=!1;if("function"==typeof define&&define.amd&&(define(e),n=!0),"object"==typeof exports&&(module.exports=e(),n=!0),!n){var o=window.Cookies,t=window.Cookies=e();t.noConflict=function(){return window.Cookies=o,t}}}(function(){function g(){for(var e=0,n={};e<arguments.length;e++){var o=arguments[e];for(var t in o)n[t]=o[t]}return n}return function e(l){function C(e,n,o){var t;if("undefined"!=typeof document){if(1<arguments.length){if("number"==typeof(o=g({path:"/"},C.defaults,o)).expires){var r=new Date;r.setMilliseconds(r.getMilliseconds()+864e5*o.expires),o.expires=r}o.expires=o.expires?o.expires.toUTCString():"";try{t=JSON.stringify(n),/^[\{\[]/.test(t)&&(n=t)}catch(e){}n=l.write?l.write(n,e):encodeURIComponent(String(n)).replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g,decodeURIComponent),e=(e=(e=encodeURIComponent(String(e))).replace(/%(23|24|26|2B|5E|60|7C)/g,decodeURIComponent)).replace(/[\(\)]/g,escape);var i="";for(var c in o)o[c]&&(i+="; "+c,!0!==o[c]&&(i+="="+o[c]));return document.cookie=e+"="+n+i}e||(t={});for(var a=document.cookie?document.cookie.split("; "):[],s=/(%[0-9A-Z]{2})+/g,f=0;f<a.length;f++){var p=a[f].split("="),d=p.slice(1).join("=");this.json||'"'!==d.charAt(0)||(d=d.slice(1,-1));try{var u=p[0].replace(s,decodeURIComponent);if(d=l.read?l.read(d,u):l(d,u)||d.replace(s,decodeURIComponent),this.json)try{d=JSON.parse(d)}catch(e){}if(e===u){t=d;break}e||(t[u]=d)}catch(e){}}return t}}return(C.set=C).get=function(e){return C.call(C,e)},C.getJSON=function(){return C.apply({json:!0},[].slice.call(arguments))},C.defaults={},C.remove=function(e,n){C(e,"",g(n,{expires:-1}))},C.withConverter=e,C}(function(){})});      
+    !function(e){var n=!1;if("function"==typeof define&&define.amd&&(define(e),n=!0),"object"==typeof exports&&(module.exports=e(),n=!0),!n){var o=window.Cookies,t=window.Cookies=e();t.noConflict=function(){return window.Cookies=o,t}}}(function(){function g(){for(var e=0,n={};e<arguments.length;e++){var o=arguments[e];for(var t in o)n[t]=o[t]}return n}return function e(l){function C(e,n,o){var t;if("undefined"!=typeof document){if(1<arguments.length){if("number"==typeof(o=g({path:"/"},C.defaults,o)).expires){var r=new Date;r.setMilliseconds(r.getMilliseconds()+864e5*o.expires),o.expires=r}o.expires=o.expires?o.expires.toUTCString():"";try{t=JSON.stringify(n),/^[\{\[]/.test(t)&&(n=t)}catch(e){}n=l.write?l.write(n,e):encodeURIComponent(String(n)).replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g,decodeURIComponent),e=(e=(e=encodeURIComponent(String(e))).replace(/%(23|24|26|2B|5E|60|7C)/g,decodeURIComponent)).replace(/[\(\)]/g,escape);var i="";for(var c in o)o[c]&&(i+="; "+c,!0!==o[c]&&(i+="="+o[c]));return document.cookie=e+"="+n+i}e||(t={});for(var a=document.cookie?document.cookie.split("; "):[],s=/(%[0-9A-Z]{2})+/g,f=0;f<a.length;f++){var p=a[f].split("="),d=p.slice(1).join("=");this.json||'"'!==d.charAt(0)||(d=d.slice(1,-1));try{var u=p[0].replace(s,decodeURIComponent);if(d=l.read?l.read(d,u):l(d,u)||d.replace(s,decodeURIComponent),this.json)try{d=JSON.parse(d)}catch(e){}if(e===u){t=d;break}e||(t[u]=d)}catch(e){}}return t}}return(C.set=C).get=function(e){return C.call(C,e)},C.getJSON=function(){return C.apply({json:!0},[].slice.call(arguments))},C.defaults={},C.remove=function(e,n){C(e,"",g(n,{expires:-1}))},C.withConverter=e,C}(function(){})});
   </script>
   <div
     id="cookie-policy-banner"
@@ -123,8 +123,8 @@
       function trackPage() {
         const path = window.location.pathname.split("/").filter(function(p){return p.trim().length>0});
         if (
-          path.length < 2 || 
-          typeof path[1] === "undefined" || 
+          path.length < 2 ||
+          typeof path[1] === "undefined" ||
           TRACKING_ROUTES.indexOf(path[1]) === -1
         ) {
           return;
@@ -150,7 +150,7 @@
     });
   </script>
   {{/* END Cookie banner, Hubspot */}}
-  
+
 
 </body>
 

--- a/layouts/partials/docs/header.html
+++ b/layouts/partials/docs/header.html
@@ -6,7 +6,7 @@
   <div class="book-brand__logo">
     {{ partial "docs/brand" . }}
   </div>
-  
+
   <label for="toc-control">
     {{ if default true (default .Site.Params.BookToC .Params.BookToC) }}
     <img src="{{ "svg/toc.svg" | relURL }}" class="book-icon" alt="Table of Contents" />

--- a/layouts/partials/docs/inject/toc-before.html
+++ b/layouts/partials/docs/inject/toc-before.html
@@ -21,7 +21,7 @@
       font-weight: 500
     }
 
-    
+
 </style>
 <br>
 <a href="https://app.alpaca.markets/signup" class="button">Sign Up</a>

--- a/layouts/partials/docs/menu-filetree.html
+++ b/layouts/partials/docs/menu-filetree.html
@@ -76,11 +76,11 @@
     </script>
   {{ end }}
 
-  {{/* If the page is part of the top nav, and is not the current page, 
+  {{/* If the page is part of the top nav, and is not the current page,
        we add the 'mobile-only' class so that it only shows up in the mobile navigation menu.
        This way when its active it shows up, and on mobile nothing is changed.  */}}
 
-  {{ if and 
+  {{ if and
     ( .Page.Params.isTopNav )
     ( not $current )
     ( not $ancestor )

--- a/themes/book/README.md
+++ b/themes/book/README.md
@@ -69,12 +69,12 @@ hugo server --minify --theme book
 
 ### File tree menu (default)
 
-By default, the theme will render pages from the `content/docs` section as a menu in a tree structure.  
+By default, the theme will render pages from the `content/docs` section as a menu in a tree structure.
 You can set `title` and `weight` in the front matter of pages to adjust the order and titles in the menu.
 
 ### Leaf bundle menu
 
-You can also use leaf bundle and the content of its `index.md` file as menu.  
+You can also use leaf bundle and the content of its `index.md` file as menu.
 Given you have the following file structure:
 
 ```
@@ -108,14 +108,14 @@ And Enable it by setting `BookMenuBundle: /menu` in Site configuration.
 
 ## Blog
 
-A simple blog is supported in the section `posts`.  
+A simple blog is supported in the section `posts`.
 A blog is not the primary usecase of this theme, so it has only minimal features.
 
 ## Configuration
 
 ### Site Configuration
 
-There are a few configuration options that you can add to your `config.toml` file.  
+There are a few configuration options that you can add to your `config.toml` file.
 You can also see the `yaml` example [here](https://github.com/alex-shpak/hugo-book/blob/master/exampleSite/config.yaml).
 
 ```toml
@@ -302,7 +302,7 @@ If you want lower maintenance, use one of the released versions. If you want to 
 
 ### [Extra credits to contributors](https://github.com/alex-shpak/hugo-book/graphs/contributors)
 
-Contributions are welcome and I will review and consider pull requests.  
+Contributions are welcome and I will review and consider pull requests.
 Primary goals are:
 
 - Keep it simple.

--- a/themes/book/assets/search.js
+++ b/themes/book/assets/search.js
@@ -35,7 +35,7 @@
 
   /**
    * @param {String} character
-   * @returns {Boolean} 
+   * @returns {Boolean}
    */
   function isHotkey(character) {
     const dataHotkeys = input.getAttribute('data-hotkeys') || '';
@@ -76,8 +76,8 @@
   }
 
   /**
-   * @param {String} src 
-   * @param {Function} callback 
+   * @param {String} src
+   * @param {Function} callback
    */
   function loadScript(src, callback) {
     const script = document.createElement('script');

--- a/themes/book/assets/sw-register.js
+++ b/themes/book/assets/sw-register.js
@@ -1,7 +1,7 @@
 {{- $swJS := resources.Get "sw.js" | resources.ExecuteAsTemplate "sw.js" . -}}
 if (navigator.serviceWorker) {
   navigator.serviceWorker.register(
-    "{{ $swJS.RelPermalink }}", 
+    "{{ $swJS.RelPermalink }}",
     { scope: "{{ "/" | relURL }}" }
   );
 }

--- a/themes/book/exampleSite/content.bn/_index.md
+++ b/themes/book/exampleSite/content.bn/_index.md
@@ -6,7 +6,7 @@ type: docs
 # বাংলা ভাষায় শুরু করুন
 
 {{< columns >}}
-## অস্ট্রিস চিপসে ফুর্তিভা 
+## অস্ট্রিস চিপসে ফুর্তিভা
 
 Est in vagis et Pittheus tu arge accipiter regia iram vocatur nurus. Omnes ut
 olivae sensit **arma sorori** deducit, inesset **crudus**, ego vetuere aliis,

--- a/themes/book/exampleSite/content/docs/shortcodes/hints.md
+++ b/themes/book/exampleSite/content/docs/shortcodes/hints.md
@@ -1,11 +1,11 @@
 # Hints
 
-Hint shortcode can be used as hint/alerts/notification block.  
+Hint shortcode can be used as hint/alerts/notification block.
 There are 3 colors to choose: `info`, `warning` and `danger`.
 
 ```tpl
 {{</* hint [info|warning|danger] */>}}
-**Markdown content**  
+**Markdown content**
 Lorem markdownum insigne. Olympo signis Delphis! Retexi Nereius nova develat
 stringit, frustra Saturnius uteroque inter! Oculis non ritibus Telethusa
 {{</* /hint */>}}
@@ -14,19 +14,19 @@ stringit, frustra Saturnius uteroque inter! Oculis non ritibus Telethusa
 ## Example
 
 {{< hint info >}}
-**Markdown content**  
+**Markdown content**
 Lorem markdownum insigne. Olympo signis Delphis! Retexi Nereius nova develat
 stringit, frustra Saturnius uteroque inter! Oculis non ritibus Telethusa
 {{< /hint >}}
 
 {{< hint warning >}}
-**Markdown content**  
+**Markdown content**
 Lorem markdownum insigne. Olympo signis Delphis! Retexi Nereius nova develat
 stringit, frustra Saturnius uteroque inter! Oculis non ritibus Telethusa
 {{< /hint >}}
 
 {{< hint danger >}}
-**Markdown content**  
+**Markdown content**
 Lorem markdownum insigne. Olympo signis Delphis! Retexi Nereius nova develat
 stringit, frustra Saturnius uteroque inter! Oculis non ritibus Telethusa
 {{< /hint >}}

--- a/themes/book/exampleSite/content/posts/creating-a-new-theme.md
+++ b/themes/book/exampleSite/content/posts/creating-a-new-theme.md
@@ -150,13 +150,13 @@ INFO: 2014/09/29 Using config file: config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [index.html _default/list.html _default/single.html]
 WARN: 2014/09/29 Unable to locate layout: [404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
-$ 
+$
 ```
 
 The "`--verbose`" flag gives extra information that will be helpful when we build the template. Every line of the output that starts with "INFO:" or "WARN:" is present because we used that flag. The lines that start with "WARN:" are warning messages. We'll go over them later.
@@ -182,7 +182,7 @@ $ ls -l public
 total 16
 -rw-r--r--  1 quoha  staff  416 Sep 29 17:02 index.xml
 -rw-r--r--  1 quoha  staff  262 Sep 29 17:02 sitemap.xml
-$ 
+$
 ```
 
 Hugo created two XML files, which is standard, but there are no HTML files.
@@ -199,9 +199,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [index.html _default/list.html _default/single.html]
 WARN: 2014/09/29 Unable to locate layout: [404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -269,7 +269,7 @@ $ find themes -type f | xargs ls -l
 -rw-r--r--  1 quoha  staff     0 Sep 29 17:31 themes/zafta/layouts/partials/footer.html
 -rw-r--r--  1 quoha  staff     0 Sep 29 17:31 themes/zafta/layouts/partials/header.html
 -rw-r--r--  1 quoha  staff    93 Sep 29 17:31 themes/zafta/theme.toml
-$ 
+$
 ```
 
 The skeleton includes templates (the files ending in .html), license file, a description of your theme (the theme.toml file), and an empty archetype.
@@ -332,9 +332,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -379,7 +379,7 @@ When Hugo created our theme, it created an empty home page template. Now, when w
 $ find . -name index.html | xargs ls -l
 -rw-r--r--  1 quoha  staff  0 Sep 29 20:21 ./public/index.html
 -rw-r--r--  1 quoha  staff  0 Sep 29 17:31 ./themes/zafta/layouts/index.html
-$ 
+$
 ```
 
 #### The Magic of Static
@@ -398,7 +398,7 @@ drwxr-xr-x  4 quoha  staff  136 Sep 29 17:31 themes/zafta/layouts/partials
 drwxr-xr-x  4 quoha  staff  136 Sep 29 17:31 themes/zafta/static
 drwxr-xr-x  2 quoha  staff   68 Sep 29 17:31 themes/zafta/static/css
 drwxr-xr-x  2 quoha  staff   68 Sep 29 17:31 themes/zafta/static/js
-$ 
+$
 ```
 
 ## The Theme Development Cycle
@@ -454,9 +454,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -468,9 +468,9 @@ INFO: 2014/09/29 File System Event: ["/Users/quoha/Sites/zafta/themes/zafta/layo
 Change detected, rebuilding site
 
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 1 ms
@@ -492,12 +492,12 @@ Right now, that page is empty because we don't have any content and we don't hav
 
 ```
 $ vi themes/zafta/layouts/index.html
-<!DOCTYPE html> 
-<html> 
-<body> 
-  <p>hugo says hello!</p> 
-</body> 
-</html> 
+<!DOCTYPE html>
+<html>
+<body>
+  <p>hugo says hello!</p>
+</body>
+</html>
 :wq
 
 $
@@ -511,9 +511,9 @@ INFO: 2014/09/29 Using config file: /Users/quoha/Sites/zafta/config.toml
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-0 pages created 
+0 draft content
+0 future content
+0 pages created
 0 tags created
 0 categories created
 in 2 ms
@@ -521,11 +521,11 @@ in 2 ms
 $ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff  78 Sep 29 21:26 public/index.html
 
-$ cat public/index.html 
-<!DOCTYPE html> 
-<html> 
-<body> 
-  <p>hugo says hello!</p> 
+$ cat public/index.html
+<!DOCTYPE html>
+<html>
+<body>
+  <p>hugo says hello!</p>
 </html>
 ```
 
@@ -534,15 +534,15 @@ $ cat public/index.html
 Note: If you're running the server with the `--watch` option, you'll see different content in the file:
 
 ```
-$ cat public/index.html 
-<!DOCTYPE html> 
-<html> 
-<body> 
-  <p>hugo says hello!</p> 
-<script>document.write('<script src="http://' 
-        + (location.host || 'localhost').split(':')[0] 
-    + ':1313/livereload.js?mindelay=10"></' 
-        + 'script>')</script></body> 
+$ cat public/index.html
+<!DOCTYPE html>
+<html>
+<body>
+  <p>hugo says hello!</p>
+<script>document.write('<script src="http://'
+        + (location.host || 'localhost').split(':')[0]
+    + ':1313/livereload.js?mindelay=10"></'
+        + 'script>')</script></body>
 </html>
 ```
 
@@ -565,7 +565,7 @@ INFO: 2014/09/29 attempting to create  post/first.md of post
 INFO: 2014/09/29 curpath: /Users/quoha/Sites/zafta/themes/zafta/archetypes/default.md
 ERROR: 2014/09/29 Unable to Cast <nil> to map[string]interface{}
 
-$ 
+$
 ```
 
 That wasn't very nice, was it?
@@ -604,7 +604,7 @@ total 16
 -rw-r--r--  1 quoha  staff  104 Sep 29 21:54 first.md
 -rw-r--r--  1 quoha  staff  105 Sep 29 21:57 second.md
 
-$ cat content/post/first.md 
+$ cat content/post/first.md
 +++
 Categories = []
 Description = ""
@@ -615,7 +615,7 @@ title = "first"
 +++
 my first post
 
-$ cat content/post/second.md 
+$ cat content/post/second.md
 +++
 Categories = []
 Description = ""
@@ -626,7 +626,7 @@ title = "second"
 +++
 my second post
 
-$ 
+$
 ```
 
 Build the web site and then verify the results.
@@ -639,9 +639,9 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"category":"categories", "tag":"tags"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
@@ -674,7 +674,7 @@ There are three other types of templates: partials, content views, and terms. We
 The home page will contain a list of posts. Let's update its template to add the posts that we just created. The logic in the template will run every time we build the site.
 
 ```
-$ vi themes/zafta/layouts/index.html 
+$ vi themes/zafta/layouts/index.html
 <!DOCTYPE html>
 <html>
 <body>
@@ -712,26 +712,26 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"tag":"tags", "category":"categories"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
-$ find public -type f -name '*.html' | xargs ls -l 
+$ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff  94 Sep 29 22:23 public/index.html
 -rw-r--r--  1 quoha  staff   0 Sep 29 22:23 public/post/first/index.html
 -rw-r--r--  1 quoha  staff   0 Sep 29 22:23 public/post/index.html
 -rw-r--r--  1 quoha  staff   0 Sep 29 22:23 public/post/second/index.html
-$ cat public/index.html 
+$ cat public/index.html
 <!DOCTYPE html>
 <html>
 <body>
-  
+
     <h1>second</h1>
-  
+
     <h1>first</h1>
-  
+
 </body>
 </html>
 $
@@ -763,7 +763,7 @@ Please see the Hugo documentation on template rendering for all the details on d
 #### Update the Template File
 
 ```
-$ vi themes/zafta/layouts/_default/single.html 
+$ vi themes/zafta/layouts/_default/single.html
 <!DOCTYPE html>
 <html>
 <head>
@@ -789,9 +789,9 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"tag":"tags", "category":"categories"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
@@ -802,7 +802,7 @@ $ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff    0 Sep 29 22:40 public/post/index.html
 -rw-r--r--  1 quoha  staff  128 Sep 29 22:40 public/post/second/index.html
 
-$ cat public/post/first/index.html 
+$ cat public/post/first/index.html
 <!DOCTYPE html>
 <html>
 <head>
@@ -815,7 +815,7 @@ $ cat public/post/first/index.html
 </body>
 </html>
 
-$ cat public/post/second/index.html 
+$ cat public/post/second/index.html
 <!DOCTYPE html>
 <html>
 <head>
@@ -858,9 +858,9 @@ INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/themes/zafta/static/ to /
 INFO: 2014/09/29 syncing from /Users/quoha/Sites/zafta/static/ to /Users/quoha/Sites/zafta/public/
 INFO: 2014/09/29 found taxonomies: map[string]string{"tag":"tags", "category":"categories"}
 WARN: 2014/09/29 Unable to locate layout: [404.html theme/404.html]
-0 draft content 
-0 future content 
-2 pages created 
+0 draft content
+0 future content
+2 pages created
 0 tags created
 0 categories created
 in 4 ms
@@ -871,15 +871,15 @@ $ find public -type f -name '*.html' | xargs ls -l
 -rw-r--r--  1 quoha  staff    0 Sep 29 22:44 public/post/index.html
 -rw-r--r--  1 quoha  staff  128 Sep 29 22:44 public/post/second/index.html
 
-$ cat public/index.html 
+$ cat public/index.html
 <!DOCTYPE html>
 <html>
 <body>
-  
+
     <h1><a href="/post/second/">second</a></h1>
-  
+
     <h1><a href="/post/first/">first</a></h1>
-  
+
 </body>
 </html>
 
@@ -906,7 +906,7 @@ Let's add an "about" page and display it at the top level (as opposed to a sub-l
 The default in Hugo is to use the directory structure of the content/ directory to guide the location of the generated html in the public/ directory. Let's verify that by creating an "about" page at the top level:
 
 ```
-$ vi content/about.md 
+$ vi content/about.md
 +++
 title = "about"
 description = "about this site"

--- a/themes/book/layouts/partials/docs/languages.html
+++ b/themes/book/layouts/partials/docs/languages.html
@@ -15,7 +15,7 @@
     <li class="flex align-center">
       <img src="{{ "svg/translate.svg" | relURL }}" class="book-icon" alt="Languages" />
       {{ $.Site.Language.LanguageName }}
-    </li> 
+    </li>
   </ul>
 
   <ul class="book-languages-list">

--- a/themes/book/layouts/partials/docs/title.html
+++ b/themes/book/layouts/partials/docs/title.html
@@ -1,4 +1,4 @@
-<!-- 
+<!--
   Partial to generate page name from Title or File name.
   Accepts Page as context
 -->


### PR DESCRIPTION
- [x] Remove trailing spaces from all files

This does not add any value to end users reading the documentation, but is just to clean trailing spaces from places that are not needed. It also helps other developers that have configured their editors to auto remove trailing spaces to not touch places that they don't want to.

These changes are a result of this command, which is finding all files not related to images/binaries and replacing trailing spaces.

```
 find . -not -name "*.jpg" -not -name "*.ttf" -not -name "*.woff" -not -name "*.woff2" -not -name"*.png"  -not \( -name .git -prune \) -type f -print0 | LANG=C LC_CTYPE=C xargs -0 sed -i '' -E "s/[[:space:]]*$//"
```