### PR TITLE
Add missing reference for Asset entity

### DIFF
--- a/content/api-references/trading-api/assets.md
+++ b/content/api-references/trading-api/assets.md
@@ -20,7 +20,7 @@ tradable with Alpaca. These assets will be marked with the flag
 ## Asset Entity
 
 ### Example
-<!-- {{< rest-entity-example name="asset-v2">}} -->
+{{< rest-entity-example name="asset-v2">}}
 
 ### Properties
-<!-- {{< rest-entity-desc name="asset-v2" >}} -->
+{{< rest-entity-desc name="asset-v2" >}}


### PR DESCRIPTION
The property table and example code are missing from the Assets page under the Trading API docs.

![image](https://user-images.githubusercontent.com/11486217/158759266-882b94c7-4ea4-4bf1-9bbc-f0196c6c5c25.png)

Turns out the reference for the Asset entity is commented out. It should now look like this:

![image](https://user-images.githubusercontent.com/11486217/158759639-f1e13f55-5a22-40af-b544-cb675e0ddef3.png)
