### PR TITLE
Add "required" param for crypto trades end point

### DIFF
--- a/data/webapi/endpoints/crypto-trades.yaml
+++ b/data/webapi/endpoints/crypto-trades.yaml
@@ -9,6 +9,7 @@ endpoints:
           - name: symbol
             type: string
             desc: The symbol to query for
+            required: true
         query:
           - name: exchanges
             type: string


### PR DESCRIPTION
Adds required param for the `SYMBOL` for the crypto trades endpoint. 

I presume it's required since one would probably only want trades for a specific symbol. Also if the symbol isn't in the path, the API returns `message: 'symbols missing'`.