### PR TITLE
Component schemas, missing endpoint and various fixes for Broker API spec

### DIFF
--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -1579,7 +1579,6 @@ components:
         signed_at:
           type: string
           example: '2019-09-11T18:09:33Z'
-          format: date-time
         ip_address:
           type: string
           format: ipv4

--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -2196,7 +2196,8 @@ components:
           minLength: 1
         processor_token:
           type: string
-          description: 'If using Plaid, you can specify a Plaid processor token here '
+          default: ""
+          description: 'If using Plaid, you can specify a Plaid processor token here'
       required:
         - account_owner_name
         - bank_account_type

--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -174,6 +174,41 @@ components:
         type: string
       description: 'TODO: find a good way to generalize the description of page_tokens'
   schemas:
+    OathClientStatus:
+      type: string
+      enum:
+        - ACTIVE
+        - DISABLED
+      description: ACTIVE or DISABLED
+      example: ACTIVE
+    AssetStatus:
+      type: string
+      enum:
+        - active
+        - inactive
+      description: active or inactive
+      example: active
+    BankAccountType:
+      type: string
+      minLength: 1
+      enum:
+        - CHECKING
+        - SAVINGS
+      description: Must be CHECKING or SAVINGS
+    AchStatus:
+      type: string
+      enum:
+        - QUEUED
+        - APPROVED
+        - PENDING
+        - CANCEL_REQUESTED
+        - SENT_TO_CLEARING
+    BankCodeType:
+      type: string
+      enum:
+        - ABA
+        - BIC
+      description: ABA (Domestic) or BIC (International)
     Account:
       type: object
       title: ''

--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -852,6 +852,7 @@ components:
         - email
     AccountConfigurations:
       title: AccountConfigurations
+      nullable: true
       type: object
       description: Represents additional configuration settings for an account
       properties:

--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -1254,7 +1254,7 @@ components:
           description: Valid only for trading activity types. Null for non-trading activites.
         qty:
           type: string
-          format: decimal
+          pattern: ([0-9]*[.])?[0-9]+
           example: '0.38921'
           description: Valid only for trading activity types. Null for non-trading activites.
         side:
@@ -1265,7 +1265,7 @@ components:
           description: Valid only for trading activity types. Null for non-trading activites.
         leaves_qty:
           type: string
-          format: decimal
+          pattern: ([0-9]*[.])?[0-9]+
           example: '0.5123'
           description: Valid only for trading activity types. Null for non-trading activites.
         order_id:
@@ -1275,7 +1275,7 @@ components:
           description: Valid only for trading activity types. Null for non-trading activites.
         cum_qty:
           type: string
-          format: decimal
+          pattern: ([0-9]*[.])?[0-9]+
           example: '0.9723'
           description: Valid only for trading activity types. Null for non-trading activites.
         order_status:

--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -2903,12 +2903,7 @@ components:
           example: Apple Inc. Common Stock
           description: The official name of the asset
         status:
-          type: string
-          enum:
-            - active
-            - inactive
-          description: active or inactive
-          example: active
+          $ref: '#/components/schemas/AssetStatus'
         tradable:
           type: boolean
           example: true
@@ -3871,12 +3866,7 @@ components:
           type: string
           description: URL of Privacy Policy
         status:
-          type: string
-          enum:
-            - ACTIVE
-            - DISABLED
-          description: ACTIVE or DISABLED
-          example: ACTIVE
+          $ref: '#/components/schemas/OathClientStatus'
         redirect_uri:
           type: array
           items:

--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -5030,6 +5030,33 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
       operationId: deleteAllOrdersForAccount
+  '/v1/trading/accounts/{account_id}/orders:by_client_order_id':
+    parameters:
+      - $ref: '#/components/parameters/AccountID'
+    get:
+      parameters:
+        - name: client_order_id
+          required: true
+          in: query
+          schema:
+            type: string
+      summary: 'Retrieves orders for the account by client_order_id parameter.'
+      tags:
+        - Trading
+      description: |-
+        Retrieves orders for the account by client_order_id parameter.
+      responses:
+        '200':
+          description: 'Retrieves orders for the account by client_order_id parameter.'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      operationId: getOrderForAccountByClientOrderId
   /v1/assets:
     get:
       tags:

--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -1780,6 +1780,7 @@ components:
         - bracket
         - oco
         - oto
+        - ''
       example: bracket
     TimeInForce:
       type: string

--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -2033,11 +2033,7 @@ components:
           type: string
           description: 9-Digit ABA RTN (Routing Number) or BIC
         bank_code_type:
-          type: string
-          enum:
-            - ABA
-            - BIC
-          description: ABA (Domestic) or BIC (International)
+          $ref: '#/components/schemas/BankCodeType'
         country:
           type: string
           description: Only for international banks
@@ -2074,11 +2070,7 @@ components:
           type: string
           description: 9-Digit ABA RTN (Routing Number) or BIC
         bank_code_type:
-          type: string
-          enum:
-            - ABA
-            - BIC
-          description: ABA (Domestic) or BIC (International)
+          $ref: '#/components/schemas/BankCodeType'
         country:
           type: string
           description: Only for international banks
@@ -2153,23 +2145,13 @@ components:
           type: string
           format: uuid
         status:
-          type: string
-          enum:
-            - QUEUED
-            - APPROVED
-            - PENDING
-            - CANCEL_REQUESTED
+          $ref: '#/components/schemas/AchStatus'
         account_owner_name:
           type: string
           minLength: 1
           description: Name of the account owner
         bank_account_type:
-          type: string
-          minLength: 1
-          enum:
-            - CHECKING
-            - SAVINGS
-          description: Must be CHECKING or SAVINGS
+          $ref: '#/components/schemas/BankAccountType'
         bank_account_number:
           type: string
           minLength: 1
@@ -2200,12 +2182,7 @@ components:
           type: string
           minLength: 1
         bank_account_type:
-          type: string
-          minLength: 1
-          enum:
-            - CHECKING
-            - SAVINGS
-          description: Must be CHECKING or SAVINGS
+          $ref: '#/components/schemas/BankAccountType'
         bank_account_number:
           type: string
           minLength: 1

--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -1486,17 +1486,29 @@ components:
               - savings
               - family
         annual_income_min:
-          type: number
+          type: string
+          pattern: ([0-9]*[.])?[0-9]+
+          example: '1.0'
         annual_income_max:
-          type: number
+          type: string
+          pattern: ([0-9]*[.])?[0-9]+
+          example: '1.0'
         liquid_net_worth_min:
-          type: number
+          type: string
+          pattern: ([0-9]*[.])?[0-9]+
+          example: '1.0'
         liquid_net_worth_max:
-          type: number
+          type: string
+          pattern: ([0-9]*[.])?[0-9]+
+          example: '1.0'
         total_net_worth_min:
-          type: number
+          type: string
+          pattern: ([0-9]*[.])?[0-9]+
+          example: '1.0'
         total_net_worth_max:
-          type: number
+          type: string
+          pattern: ([0-9]*[.])?[0-9]+
+          example: '1.0'
         extra:
           type: object
           description: |

--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -640,6 +640,7 @@ components:
             city: San Mateo
             state: CA
             postal_code: '94401'
+            unit: '31'
           identity:
             given_name: Strange
             family_name: Elbakyan
@@ -758,6 +759,7 @@ components:
             city: San Mateo
             state: CA
             postal_code: '94401'
+            unit: '42'
           identity:
             given_name: John
             family_name: Doe
@@ -1428,6 +1430,9 @@ components:
         postal_code:
           type: string
           example: '94401'
+        unit:
+          type: string
+          example: '31'
     Identity:
       type: object
       description: |

--- a/oas/broker/openapi.yaml
+++ b/oas/broker/openapi.yaml
@@ -551,6 +551,7 @@ components:
         - DISABLE_PENDING
         - ACCOUNT_CLOSED
         - PAPER_ONLY
+        - INACTIVE
       description: |
         Designates the current status of this account
 


### PR DESCRIPTION
Added new components schemas declaration for: 
* OathClientStatus
* AssetStatus
* BankAccountType
* AchStatus
* BankCodeType

Added missing endpoint for `/v1/trading/accounts/{account_id}/orders:by_client_order_id`

Added missing items for multiple enums and `Contact` component and fixed incorrect numbers declaration.

# QA
* Linter passes without issues and new warnings.
* Validation passes without issues:
```shell
$ npm run validate broker/openapi.yaml 

> alpaca-oas@0.0.1 validate
> swagger-cli validate

broker/openapi.yaml is valid
```