### PR TITLE
Updated getting started to use correct import

### DIFF
--- a/content/market-data/getting-started.md
+++ b/content/market-data/getting-started.md
@@ -111,7 +111,7 @@ instantiate the crypto historical data client. It's not required for this
 client to pass in API keys or a paper URL.
 
 ```py
-from alpaca.data.historical import CryptoHistoricalDataClient
+from alpaca.data.historical.crypto import CryptoHistoricalDataClient
 
 # No keys required for crypto data
 client = CryptoHistoricalDataClient()


### PR DESCRIPTION
In the getting started section, the import that is used is incorrect for the CryptoHistoricalDataClient.
It was missing ".crypto"